### PR TITLE
Lock prom-client dependency to last working version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4009,6 +4009,14 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
+    "prom-client": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.2.0.tgz",
+      "integrity": "sha512-wGr5mlNNdRNzEhRYXgboUU2LxHWIojxscJKmtG3R8f4/KiWqyYgXTLHs0+Ted7tG3zFT7pgHJbtomzZ1L0ARaQ==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fast-stats": "^0.0.6",
     "moment": "^2.29.1",
     "pidusage": "^2.0.21",
-    "prom-client": "https://github.com/siimon/prom-client#master",
+    "prom-client": "^13.2.0",
     "ps-tree": "^1.2.0",
     "puppeteer": "^10.0.0",
     "request": "^2.88.2",


### PR DESCRIPTION
Version 14 of [prom-client](https://www.npmjs.com/package/prom-client) introduces some breaking API changes that cause the WebRTC Stress Tests to fail at startup when `prometheus-pushgateway` is set.

This PR locks the dependency down to version 13 – the last version compatible with this tool suite.