### PR TITLE
Add missing datasource uid

### DIFF
--- a/examples/kurento-one2one-direct.js
+++ b/examples/kurento-one2one-direct.js
@@ -1,0 +1,43 @@
+//var peerPairs = [[{name: 1, set: false }, {name: 2, set: false }]];
+//var name = {name: 1, set: false };
+//var peer = {name: 2, set: false };
+
+/*
+function setName() {
+  var nameInput = document.querySelector('#id');
+  peerPairs.forEach(element => {
+    if (!element[1].set){
+      name = element[1].name
+    }else if (!element[2].set){
+      name = element[2].name
+    }
+  });
+  nameInput.value = peerPairs[1].name
+  const registerButton = document.querySelector('#register');
+}*/
+
+function setPeer() {
+  const peerInput = document.querySelector('#peer')
+  const peerDisplay = document.querySelector('#display_peer')
+  peerInput.value = peerDisplay.innerHTML
+  //console.log("peerdisplayinnerhtml " + peerDisplay.innerHTML + " peerinputvalue " +peerInput.value)
+}
+
+/**
+ * Gets, sets and then joins the peer.
+ */
+function kurentoJoin() {
+  //setName()
+  const joinButton = document.querySelector('#call')
+
+  if (!joinButton) {
+    setTimeout(kurentoJoin, 1000)
+    return
+  }
+  setPeer()
+
+  // join the room
+  console.log(`Joining the room`)
+  joinButton.click()
+}
+setTimeout(kurentoJoin, 2000)

--- a/prometheus-stack/config/grafana-prometheus-datasource.yml
+++ b/prometheus-stack/config/grafana-prometheus-datasource.yml
@@ -26,3 +26,4 @@ datasources:
     tlsClientKey: ""
   version: 1
   editable: true
+  uid: "2_miEJT7k"

--- a/src/session.ts
+++ b/src/session.ts
@@ -641,7 +641,7 @@ export class Session extends EventEmitter {
           ? puppeteerExtra
           : puppeteer
         ).launch({
-          headless: !this.display,
+          headless: !this.display ? 'new' : false,
           executablePath,
           handleSIGINT: false,
           env,

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1297,6 +1297,8 @@ export class Stats extends events.EventEmitter {
             body as string
           }`,
         )
+      } else {
+        log.debug(`Message pushed successfully: ${JSON.stringify(body)}`)
       }
     } catch (err) {
       log.error(`Pushgateway push error: ${(err as Error).message}`)

--- a/url.txt
+++ b/url.txt
@@ -1,0 +1,16 @@
+#livekit
+yarn start --sessions=1 \
+--url="http://localhost:3000/#/room" \
+--url-query='url=ws%3A%2F%2Flocalhost%3A7880&token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODg4MDc2MDAsImlzcyI6ImRldmtleSIsIm5hbWUiOiJ1c2VyMiIsIm5iZiI6MTY4ODcyMTIwMCwic3ViIjoidXNlcjIiLCJ2aWRlbyI6eyJyb29tIjoibG9hZC10ZXN0Iiwicm9vbUpvaW4iOnRydWV9fQ.pzIhg2dCSFSXyaYlfGwKzZlL0DBvJGcmzRLQ48Kn2Dc&videoEnabled=1&audioEnabled=1&simulcast=1&dynacast=1&adaptiveStream=1&videoDeviceId=4b8757b64f9507870a81db740c98fdd9727f65018317997906094ba172357eef'
+
+#kurento
+yarn start \
+--url="https://localhost:8443/#" \
+--script-path=examples/kurento-one2one-direct.js \
+--prometheus-pushgateway=http://localhost:9091 \
+--prometheus-pushgateway-gzip=false \
+--show-page-log=false \
+--tabs-per-session=1 \
+--sessions=1
+
+


### PR DESCRIPTION
Using the newly added dashboard I encountered an error, that grafana could find the datasource with a given uid. I realized that it was missing from the edited file. It worked for you because the uid was probably (created and) cached in your docker volume so you didn't come across this problem.
Read more: https://community.grafana.com/t/should-provisioned-dashboards-have-datasource-uids/65463/4

Might not be the fix that you want but just wanted to let you know about this uid problem