### PR TITLE
Grafana: Add missing datasource uid

### DIFF
--- a/prometheus-stack/config/grafana-prometheus-datasource.yml
+++ b/prometheus-stack/config/grafana-prometheus-datasource.yml
@@ -26,3 +26,4 @@ datasources:
     tlsClientKey: ""
   version: 1
   editable: true
+  uid: "2_miEJT7k"


### PR DESCRIPTION
Using the newly added dashboard I encountered an error, that grafana could find the datasource with a given uid. I realized that it was missing from the edited file. It worked for you because the uid was probably (created and) cached in your docker volume so you didn't come across this problem.
Read more: https://community.grafana.com/t/should-provisioned-dashboards-have-datasource-uids/65463/4

Might not be the fix that you want but just wanted to let you know about this uid problem